### PR TITLE
fix:  Unable to create metrics

### DIFF
--- a/app/springboot/pom.xml
+++ b/app/springboot/pom.xml
@@ -44,7 +44,6 @@
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-prometheus</artifactId>
-			<version>1.13.1</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
## Expected Behavior

`/actuator/prometheus` is able to expose metrics.

## Actual Behavior

`/actuator/prometheus` is unable to expose metrics.

## Steps to Reproduce the Problem

1. clone repo
2. cd 05-prometheus
3. docker-compose up -d



